### PR TITLE
build: update node and npm engines versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,65 +1,65 @@
 {
-	"name": "sketch_picker",
-	"version": "0.0.1",
-	"description": "Text templates",
-	"main": "index.js",
-	"directories": {
-		"test": "tests"
-	},
-	"scripts": {
-		"build": "NODE_ENV=production webpack --progress --config webpack.js",
-		"dev": "NODE_ENV=development webpack --progress --config webpack.js",
-		"watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
-		"lint": "eslint --ext .js,.vue src",
-		"lint:fix": "eslint --ext .js,.vue src --fix",
-		"stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
-		"stylelint:fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/julien-nc/sketch_picker"
-	},
-	"keywords": [
-		"templates"
-	],
-	"author": "Julien Veyssier",
-	"license": "AGPL-3.0",
-	"bugs": {
-		"url": "https://github.com/julien-nc/sketch_picker/issues"
-	},
-	"homepage": "https://github.com/julien-nc/sketch_picker",
-	"browserslist": [
-		"extends @nextcloud/browserslist-config"
-	],
-	"engines": {
-		"node": "^16 || ^17 || ^18 || ^19 || ^20",
-		"npm": "^7.0.0 || ^8.0.0 || ^9.0.0"
-	},
-	"dependencies": {
-		"@nextcloud/auth": "^2.0.0",
-		"@nextcloud/axios": "^2.0.0",
-		"@nextcloud/dialogs": "^7.1.0",
-		"@nextcloud/event-bus": "^3.1.0",
-		"@nextcloud/initial-state": "^3.0.0",
-		"@nextcloud/l10n": "^3.1.0",
-		"@nextcloud/moment": "^1.1.1",
-		"@nextcloud/router": "^3.0.0",
-		"@nextcloud/vue": "^9.1.0",
-		"filerobot-image-editor": "^4.5.0",
-		"path": "^0.12.7",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
-		"react-konva": "^18.2.14",
-		"vue": "^3.5.22",
-		"vue-material-design-icons": "^5.1.2"
-	},
-	"devDependencies": {
-		"@nextcloud/babel-config": "^1.0.0",
-		"@nextcloud/browserslist-config": "^3.0.0",
-		"@nextcloud/eslint-config": "^8.0.0",
-		"@nextcloud/stylelint-config": "^3.0.1",
-		"@nextcloud/webpack-vue-config": "^6.0.0",
-		"eslint-webpack-plugin": "^4.0.0",
-		"stylelint-webpack-plugin": "^5.0.0"
-	}
+  "name": "sketch_picker",
+  "version": "0.0.1",
+  "description": "Text templates",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "NODE_ENV=production webpack --progress --config webpack.js",
+    "dev": "NODE_ENV=development webpack --progress --config webpack.js",
+    "watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
+    "lint": "eslint --ext .js,.vue src",
+    "lint:fix": "eslint --ext .js,.vue src --fix",
+    "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
+    "stylelint:fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/julien-nc/sketch_picker"
+  },
+  "keywords": [
+    "templates"
+  ],
+  "author": "Julien Veyssier",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/julien-nc/sketch_picker/issues"
+  },
+  "homepage": "https://github.com/julien-nc/sketch_picker",
+  "browserslist": [
+    "extends @nextcloud/browserslist-config"
+  ],
+  "engines": {
+    "node": "^24.0.0",
+    "npm": "^11.3.0"
+  },
+  "dependencies": {
+    "@nextcloud/auth": "^2.0.0",
+    "@nextcloud/axios": "^2.0.0",
+    "@nextcloud/dialogs": "^7.1.0",
+    "@nextcloud/event-bus": "^3.1.0",
+    "@nextcloud/initial-state": "^3.0.0",
+    "@nextcloud/l10n": "^3.1.0",
+    "@nextcloud/moment": "^1.1.1",
+    "@nextcloud/router": "^3.0.0",
+    "@nextcloud/vue": "^9.1.0",
+    "filerobot-image-editor": "^4.5.0",
+    "path": "^0.12.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-konva": "^18.2.14",
+    "vue": "^3.5.22",
+    "vue-material-design-icons": "^5.1.2"
+  },
+  "devDependencies": {
+    "@nextcloud/babel-config": "^1.0.0",
+    "@nextcloud/browserslist-config": "^3.0.0",
+    "@nextcloud/eslint-config": "^8.0.0",
+    "@nextcloud/stylelint-config": "^3.0.1",
+    "@nextcloud/webpack-vue-config": "^6.0.0",
+    "eslint-webpack-plugin": "^4.0.0",
+    "stylelint-webpack-plugin": "^5.0.0"
+  }
 }


### PR DESCRIPTION
Automated update of the npm and node engines versions according to [Nextcloud standards](https://github.com/nextcloud/standards/issues/5).